### PR TITLE
Enable headless server support, fix missing iFrames issue, and add new ShaderToy example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+frames
+output.mp4

--- a/demo_run.sh
+++ b/demo_run.sh
@@ -1,0 +1,2 @@
+./shaderdump.py -i examples/zippyzaps.frag -o frames/frames_%04d.jpg -t0 0.0 -t1 4. -fps 60
+ffmpeg -framerate 60 -i frames/frames_%04d.jpg -c:v libx264 -pix_fmt yuv420p output.mp4

--- a/examples/zippyzaps.frag
+++ b/examples/zippyzaps.frag
@@ -1,0 +1,25 @@
+// https://www.shadertoy.com/view/XXyGzh
+void mainImage( out vec4 o, vec2 u )
+{
+    vec2 v = iResolution.xy;
+         u = .2*(u+u-v)/v.y;    
+         
+    vec4 z = o = vec4(1,2,3,0);
+     
+    for (float a = .5, t = iTime, i; 
+         ++i < 19.; 
+         o += (1. + cos(z+t)) 
+            / length((1.+i*dot(v,v)) 
+                   * sin(1.5*u/(.5-dot(u,u)) - 9.*u.yx + t))
+         )  
+        v = cos(++t - 7.*u*pow(a += .03, i)) - 5.*u,                 
+        u += tanh(40. * dot(u *= mat2(cos(i + .02*t - vec4(0,11,33,0)))
+                           ,u)
+                      * cos(1e2*u.yx + t)) / 2e2
+           + .2 * a * u
+           + cos(4./exp(dot(o,o)/1e2) + t) / 3e2;
+              
+     o = 25.6 / (min(o, 13.) + 164. / o) 
+       - dot(u, u) / 250.;
+}
+

--- a/shaderdump.py
+++ b/shaderdump.py
@@ -29,7 +29,7 @@ END_TIME = args.endTime
 FPS = args.framesPerSecond
 
 # === CONTEXT SETUP ===
-ctx = moderngl.create_standalone_context()
+ctx = moderngl.create_standalone_context(backend='egl')
 
 # === SHADER SETUP ===
 with open(SHADER_PATH) as f:
@@ -48,9 +48,15 @@ uniform int iFrame;
 
 {user_code}
 
+
+
 void main() {{
     float f = float(iFrame) / 60.0;
     mainImage(fragColor, gl_FragCoord.xy);
+    // Force the compiler to think f is used
+    if (f < -1.0) {{
+        fragColor = vec4(1.0);  // never executed, but f is "used"
+    }}
 }}
 """
 
@@ -127,6 +133,7 @@ for frame in range(num_frames):
     # Set shader uniforms
     prog['iResolution'].value = (RENDER_W, RENDER_H, 1.0)
     prog['iTime'].value = t
+
     prog['iFrame'].value = frame
 
     # Render to supersampled target


### PR DESCRIPTION
It turns out by setting "ctx = moderngl.create_standalone_context(backend='egl')", we can run from the headless server.

Also, the variables like 'iFrame', e.t.c. will be optimized out if not used. So to prevent this happing a dummy use of the iFrame is added.

Finally a demo run sh is added where a simple 'bash demo_run.sh' will render the images and create the video with ffmpeg.